### PR TITLE
Check pod delete time when pod update

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -262,7 +262,7 @@ func (v *VirtualK8S) buildPodInformer(podInformer informerv1.PodInformer) {
 					}
 					v.updateVKCapacityFromPod(oldCopy, newCopy)
 				}
-				if !reflect.DeepEqual(oldCopy.Status, newCopy.Status) {
+				if !reflect.DeepEqual(oldCopy.Status, newCopy.Status) || newCopy.DeletionTimestamp != nil {
 					util.TrimObjectMeta(&newCopy.ObjectMeta)
 					v.updatedPod <- newCopy
 				}


### PR DESCRIPTION
Bugfix: when pod is deleted in lower cluster due to some cases pod can not be delete in upper cluster