### PR TITLE
fix nodeInformer cache

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -72,6 +72,8 @@ type strategyFunction func(ctx context.Context, client clientset.Interface, stra
 func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer, deschedulerPolicy *api.DeschedulerPolicy, evictionPolicyGroupVersion string, stopChannel chan struct{}) error {
 	sharedInformerFactory := informers.NewSharedInformerFactory(rs.Client, 0)
 	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
+	// just trigger sharedInformerFactory add node informers
+	nodeInformer.Informer()
 
 	sharedInformerFactory.Start(stopChannel)
 	sharedInformerFactory.WaitForCacheSync(stopChannel)


### PR DESCRIPTION
#74 

## log

```shell
$ go run ./cmd/descheduler/descheduler.go --kubeconfig=~/Dropbox/k8sconfig/dev-test/test-bus-gz-01-idc.yaml -v 5 --policy-config-file=~/demo/virtual-kubelet/policy.yaml --descheduling-interval=5s
I0602 10:54:54.626375   45041 reflector.go:175] Starting reflector *v1.Node (0s) from pkg/mod/k8s.io/client-go@v0.18.4/tools/cache/reflector.go:125
I0602 10:54:54.626496   45041 reflector.go:211] Listing and watching *v1.Node from pkg/mod/k8s.io/client-go@v0.18.4/tools/cache/reflector.go:125
I0602 10:54:54.830745   45041 shared_informer.go:253] caches populated
I0602 10:54:54.830906   45041 pod_lifetime.go:45] Processing node: "10.27.185.241"
I0602 10:54:54.830907   45041 pod_lifetime.go:45] Processing node: "10.27.187.241"
I0602 10:54:54.830914   45041 pod_lifetime.go:45] Processing node: "10.27.184.243"
I0602 10:54:54.830935   45041 pod_lifetime.go:45] Processing node: "10.27.185.243"
I0602 10:54:54.831019   45041 pod_lifetime.go:45] Processing node: "10.27.185.242"
I0602 10:54:54.831035   45041 pod_lifetime.go:45] Processing node: "10.27.186.241"
I0602 10:54:54.831073   45041 pod_lifetime.go:45] Processing node: "10.27.186.242"
I0602 10:54:54.831076   45041 pod_lifetime.go:45] Processing node: "10.27.184.242"
I0602 10:54:54.831194   45041 pod_lifetime.go:45] Processing node: "10.27.184.241"
I0602 10:54:59.910677   45041 pod_lifetime.go:45] Processing node: "10.27.185.241"
I0602 10:54:59.910729   45041 pod_lifetime.go:45] Processing node: "10.27.187.241"
I0602 10:54:59.910756   45041 pod_lifetime.go:45] Processing node: "10.27.186.242"
I0602 10:54:59.910813   45041 pod_lifetime.go:45] Processing node: "10.27.185.242"
I0602 10:54:59.910824   45041 pod_lifetime.go:45] Processing node: "10.27.184.243"
I0602 10:54:59.910849   45041 pod_lifetime.go:45] Processing node: "10.27.184.241"
I0602 10:54:59.910861   45041 pod_lifetime.go:45] Processing node: "10.27.185.243"
I0602 10:54:59.910907   45041 pod_lifetime.go:45] Processing node: "10.27.186.241"
I0602 10:54:59.910909   45041 pod_lifetime.go:45] Processing node: "10.27.184.242"
I0602 10:55:04.912782   45041 pod_lifetime.go:45] Processing node: "10.27.186.242"
I0602 10:55:04.912795   45041 pod_lifetime.go:45] Processing node: "10.27.184.243"
I0602 10:55:04.912797   45041 pod_lifetime.go:45] Processing node: "10.27.185.243"
I0602 10:55:04.912806   45041 pod_lifetime.go:45] Processing node: "10.27.186.241"
I0602 10:55:04.912797   45041 pod_lifetime.go:45] Processing node: "10.27.185.241"
I0602 10:55:04.912841   45041 pod_lifetime.go:45] Processing node: "10.27.184.242"
I0602 10:55:04.912784   45041 pod_lifetime.go:45] Processing node: "10.27.184.241"
I0602 10:55:04.912871   45041 pod_lifetime.go:45] Processing node: "10.27.187.241"
I0602 10:55:04.912787   45041 pod_lifetime.go:45] Processing node: "10.27.185.242"
```