### PR TITLE
tripped ignore labels before update pod

### DIFF
--- a/pkg/provider/pod.go
+++ b/pkg/provider/pod.go
@@ -120,8 +120,11 @@ func (v *VirtualK8S) UpdatePod(ctx context.Context, pod *corev1.Pod) error {
 		klog.Info("Pod is not created by vk, ignore")
 		return nil
 	}
-
+	//tripped ignore labels which recoverd in currentPod
+	util.TrimLabels(currentPod.ObjectMeta.Labels, v.ignoreLabels)
 	podCopy := currentPod.DeepCopy()
+	// util.GetUpdatedPod update PodCopy container image, annotations, labels.
+	// recover toleration, affinity, tripped ignore labels.
 	util.GetUpdatedPod(podCopy, pod, v.ignoreLabels)
 	if reflect.DeepEqual(currentPod.Spec, podCopy.Spec) &&
 		reflect.DeepEqual(currentPod.Annotations, podCopy.Annotations) &&

--- a/pkg/util/conversions.go
+++ b/pkg/util/conversions.go
@@ -53,7 +53,7 @@ func TrimPod(pod *corev1.Pod, ignoreLabels []string) *corev1.Pod {
 	podCopy.Spec.NodeName = ""
 	podCopy.Status = corev1.PodStatus{}
 	// remove labels should be removed, which would influence schedule in client cluster
-	tripped := trimLabels(podCopy.ObjectMeta.Labels, ignoreLabels)
+	tripped := TrimLabels(podCopy.ObjectMeta.Labels, ignoreLabels)
 	if tripped != nil {
 		trippedStr, err := json.Marshal(tripped)
 		if err != nil {
@@ -106,7 +106,7 @@ func GetUpdatedPod(orig, update *corev1.Pod, ignoreLabels []string) {
 	orig.Annotations = update.Annotations
 	orig.Spec.ActiveDeadlineSeconds = update.Spec.ActiveDeadlineSeconds
 	if orig.Labels != nil {
-		trimLabels(orig.ObjectMeta.Labels, ignoreLabels)
+		TrimLabels(orig.ObjectMeta.Labels, ignoreLabels)
 	}
 	return
 }
@@ -174,8 +174,8 @@ func recoverSelectors(pod *corev1.Pod, cns *ClustersNodeSelection) {
 	}
 }
 
-// trimLabels removes label from labels according to ignoreLabels
-func trimLabels(labels map[string]string, ignoreLabels []string) map[string]string {
+// TrimLabels removes label from labels according to ignoreLabels
+func TrimLabels(labels map[string]string, ignoreLabels []string) map[string]string {
 	if ignoreLabels == nil {
 		return nil
 	}


### PR DESCRIPTION
When provider update pod to lower cluster,  `currentpod` should get from clientcache and not recover label from annotation.
