### PR TITLE
set DeletionGracePeriodSeconds to nil when sync pod status from provider

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -297,6 +297,12 @@ func (v *VirtualK8S) updatePod(oldObj, newObj interface{}) {
 		v.updateVKCapacityFromPod(oldCopy, newCopy)
 		return
 	}
+	// when pod deleted in lower cluster
+	// set DeletionGracePeriodSeconds to nil because it's readOnly
+	if newCopy.DeletionTimestamp != nil {
+		newCopy.DeletionGracePeriodSeconds = nil
+	}
+
 	if !reflect.DeepEqual(oldCopy.Status, newCopy.Status) || newCopy.DeletionTimestamp != nil {
 		util.TrimObjectMeta(&newCopy.ObjectMeta)
 		v.updatedPod <- newCopy


### PR DESCRIPTION
Signed-off-by: Kun Zhang <scuzk373x@gmail.com>

If sync terminating pod status from lower cluster to upper cluster.  It needs set `DeleteionGracePeriodSeconds` to nil 
because it's  readOnly. 