### PR TITLE
Introduce additional env vars.

### DIFF
--- a/pkg/provider/helper.go
+++ b/pkg/provider/helper.go
@@ -104,3 +104,12 @@ func podStopped(pod *corev1.Pod) bool {
 	return (pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed) && pod.Spec.
 		RestartPolicy == corev1.RestartPolicyNever
 }
+
+// nodeCustomLabel adds an additional node label.
+// The label can be any customised meaningful label specified from user.
+func nodeCustomLabel(node *corev1.Node, label string) {
+	nodelabel := strings.Split(label, ":")
+	if len(nodelabel) == 2 {
+		node.ObjectMeta.Labels[strings.TrimSpace(nodelabel[0])] = strings.TrimSpace(nodelabel[1])
+	}
+}

--- a/pkg/provider/node.go
+++ b/pkg/provider/node.go
@@ -62,7 +62,13 @@ func (v *VirtualK8S) ConfigureNode(ctx context.Context, node *corev1.Node) {
 	node.ObjectMeta.Labels[corev1.LabelArchStable] = "amd64"
 	node.ObjectMeta.Labels[corev1.LabelOSStable] = "linux"
 	node.ObjectMeta.Labels[util.LabelOSBeta] = "linux"
+	if label := os.Getenv("VKUBELET_NODE_LABEL"); label != "" {
+		nodeCustomLabel(node, label)
+	}
 	node.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: os.Getenv("VKUBELET_POD_IP")}}
+	if externalIP := os.Getenv("VKUBELET_EXTERNAL_POD_IP"); externalIP != "" {
+		node.Status.Addresses = append(node.Status.Addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: externalIP})
+	}
 	node.Status.Conditions = nodeConditions()
 	node.Status.DaemonEndpoints = v.nodeDaemonEndpoints()
 	v.providerNode.Node = node


### PR DESCRIPTION
Introducing some helpful new env vars.
Added VKUBELET_EXTERNAL_POD_IP for adding a Node external IP information. 
Added VKUBELET_NODE_LABEL env variable for adding an additional custom Node label besides the 'agent' label.

It's really useful to have the Node external IP in some cases like this.
```
vmss00000p   Ready    agent          3d3h   v1.25.6        10.224.0.4    <none>        Ubuntu 22.04.2 LTS   5.15.0-1034-azure   containerd://1.6.18+azure-1
worker1      Ready    agent,worker   179m   v1.25.6+k3s1   10.224.0.4    10.0.0.4      <unknown>            <unknown>           <unknown>
worker2      Ready    agent,worker   3h1m   v1.25.6+k3s1   10.224.0.4    10.0.0.5      <unknown>            <unknown>           <unknown>
```
Some k8s extensions make use of this information in some ways.
Similar situation is with the additional Node label. 
In our case we are using the self-node-remediation operator from the medik8s.io .
Of course the new env vars here are purely optional and take effect only when they are set on purpose.
